### PR TITLE
Improves SoC and injection of data into modules

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,16 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/dhii/collections-interface" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/dhii/config-interface" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/dhii/data-container-interface" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/dhii/factory-base" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/dhii/file-finder-abstract" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/dhii/modular-interface" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/dhii/module-interface" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/dhii/php-cs-fixer-config" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/dhii/wp-events" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/rebelcode/module-iterator-abstract" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/vendor/symfony/debug" vcs="Git" />
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [[*next-version*]] - YYYY-MM-DD
+### Added
+- Modules that extend `AbstractBaseMap` may now get injected with a config map.
+- Modules that extend `AbstractBaseMap` no longer need to implement a constructor equivalent for `_initModule()`.
+
+### Changed
+- Modules that extend `AbstractBaseMap` now receive their key and dependencies in the new config map.
+- Modules that extend `AbstractBaseMap` merge the injected config into the final setup config.
 
 ## [0.1-alpha1] - 2018-05-11
 Initial version.

--- a/src/Config/ConfigAwareTrait.php
+++ b/src/Config/ConfigAwareTrait.php
@@ -2,10 +2,10 @@
 
 namespace RebelCode\Modular\Config;
 
+use Dhii\Config\ConfigInterface;
+use Dhii\Util\String\StringableInterface as Stringable;
+use Exception as RootException;
 use InvalidArgumentException;
-use Psr\Container\ContainerInterface;
-use ArrayAccess;
-use stdClass;
 
 /**
  * Functionality for awareness of a configuration container.
@@ -17,7 +17,7 @@ trait ConfigAwareTrait
     /**
      * The configuration container.
      *
-     * @var array|ArrayAccess|stdClass|ContainerInterface
+     * @var ConfigInterface
      */
     protected $config;
 
@@ -26,7 +26,7 @@ trait ConfigAwareTrait
      *
      * @since [*next-version*]
      *
-     * @return array|ArrayAccess|stdClass|ContainerInterface
+     * @return ConfigInterface The configuration container instance.
      */
     protected function _getConfig()
     {
@@ -38,27 +38,55 @@ trait ConfigAwareTrait
      *
      * @since [*next-version*]
      *
-     * @param array|ArrayAccess|stdClass|ContainerInterface $config The configuration container.
+     * @param ConfigInterface $config The configuration container instance.
      *
      * @throws InvalidArgumentException If the configuration container is invalid.
      */
     protected function _setConfig($config)
     {
-        $this->config = $this->_normalizeContainer($config);
+        if (!($config instanceof ConfigInterface)) {
+            throw $this->_createInvalidArgumentException(
+                $this->__('Argument is not a config instance'),
+                null,
+                null,
+                $config
+            );
+        }
+
+        $this->config = $config;
     }
 
     /**
-     * Normalizes a container.
+     * Creates a new Dhii invalid argument exception.
      *
      * @since [*next-version*]
      *
-     * @param array|ArrayAccess|stdClass|ContainerInterface $container The container to normalize.
+     * @param string|Stringable|int|float|bool|null $message  The message, if any.
+     * @param int|float|string|Stringable|null      $code     The numeric error code, if any.
+     * @param RootException|null                    $previous The inner exception, if any.
+     * @param mixed|null                            $argument The invalid argument, if any.
      *
-     * @throws InvalidArgumentException If the container is invalid.
-     *
-     * @return array|ArrayAccess|stdClass|ContainerInterface Something that can be used with
-     *                                                       {@see ContainerGetCapableTrait#_containerGet()} or
-     *                                                       {@see ContainerHasCapableTrait#_containerHas()}.
+     * @return InvalidArgumentException The new exception.
      */
-    abstract protected function _normalizeContainer($container);
+    abstract protected function _createInvalidArgumentException(
+        $message = null,
+        $code = null,
+        RootException $previous = null,
+        $argument = null
+    );
+
+    /**
+     * Translates a string, and replaces placeholders.
+     *
+     * @since [*next-version*]
+     * @see   sprintf()
+     * @see   _translate()
+     *
+     * @param string $string  The format string to translate.
+     * @param array  $args    Placeholder values to replace in the string.
+     * @param mixed  $context The context for translation.
+     *
+     * @return string The translated string.
+     */
+    abstract protected function __($string, $args = [], $context = null);
 }

--- a/src/Module/AbstractBaseModule.php
+++ b/src/Module/AbstractBaseModule.php
@@ -238,10 +238,10 @@ abstract class AbstractBaseModule implements
      *
      * @since [*next-version*]
      *
-     * @param array|stdClass|ArrayAccess|ContainerInterface $config               The module config.
-     * @param ConfigFactoryInterface                        $configFactory        The config factory.
-     * @param ContainerFactoryInterface                     $containerFactory     The container factory.
-     * @param ContainerFactoryInterface                     $compContainerFactory The composite container factory.
+     * @param array|stdClass|Traversable $config               The module config.
+     * @param ConfigFactoryInterface     $configFactory        The config factory.
+     * @param ContainerFactoryInterface  $containerFactory     The container factory.
+     * @param ContainerFactoryInterface  $compContainerFactory The composite container factory.
      */
     protected function _initModule(
         $config,

--- a/src/Module/AbstractBaseModule.php
+++ b/src/Module/AbstractBaseModule.php
@@ -249,13 +249,17 @@ abstract class AbstractBaseModule implements
         ContainerFactoryInterface $containerFactory,
         ContainerFactoryInterface $compContainerFactory
     ) {
-        $this->_setKey($this->_containerGet($config, 'key'));
+        $config = $configFactory->make([
+            ConfigFactoryInterface::K_DATA => $config,
+        ]);
+
+        $this->_setConfig($config);
+        $this->_setKey($config->get('key'));
         $this->_setDependencies(
-            $this->_containerHas($config, 'dependencies')
-                ? $this->_containerGet($config, 'dependencies')
+            $config->has('dependencies')
+                ? $config->get('dependencies')
                 : []
         );
-        $this->_setConfig($config);
         $this->_setConfigFactory($configFactory);
         $this->_setContainerFactory($containerFactory);
         $this->_setCompositeContainerFactory($compContainerFactory);

--- a/src/Module/AbstractBaseModule.php
+++ b/src/Module/AbstractBaseModule.php
@@ -31,6 +31,7 @@ use InvalidArgumentException;
 use OutOfRangeException;
 use Psr\Container\ContainerInterface;
 use Psr\EventManager\EventManagerInterface;
+use RebelCode\Modular\Config\ConfigAwareTrait;
 use RebelCode\Modular\Events\EventsFunctionalityTrait;
 use RuntimeException;
 use stdClass;
@@ -54,6 +55,13 @@ abstract class AbstractBaseModule implements
         _getKey as public getKey;
         _getDependencies as public getDependencies;
     }
+
+    /*
+     * Provides awareness of module config.
+     *
+     * @since [*next-version*]
+     */
+    use ConfigAwareTrait;
 
     /*
      * Provides functionality for retrieving a value for a path from any type of container hierarchy.
@@ -161,6 +169,20 @@ abstract class AbstractBaseModule implements
     use StringTranslatingTrait;
 
     /**
+     * The key in the module config where the module key can be found.
+     *
+     * @since [*next-version*]
+     */
+    const K_CONFIG_KEY = 'key';
+
+    /**
+     * The key in the module config where the module dependencies can be found.
+     *
+     * @since [*next-version*]
+     */
+    const K_CONFIG_DEPENDENCIES = 'dependencies';
+
+    /**
      * The factory to use for creating containers.
      *
      * @since [*next-version*]
@@ -188,25 +210,52 @@ abstract class AbstractBaseModule implements
     protected $compContainerFactory;
 
     /**
+     * Constructor.
+     *
+     * @since [*next-version*]
+     *
+     * @param array|stdClass|ArrayAccess|ContainerInterface $config               The module config.
+     * @param ConfigFactoryInterface                        $configFactory        The config factory.
+     * @param ContainerFactoryInterface                     $containerFactory     The container factory.
+     * @param ContainerFactoryInterface                     $compContainerFactory The composite container factory.
+     * @param EventManagerInterface|null                    $eventManager         The event manager, or null.
+     * @param EventFactoryInterface|null                    $eventFactory         The event factory, or null.
+     */
+    public function __construct(
+        $config,
+        ConfigFactoryInterface $configFactory,
+        ContainerFactoryInterface $containerFactory,
+        ContainerFactoryInterface $compContainerFactory,
+        EventManagerInterface $eventManager = null,
+        EventFactoryInterface $eventFactory = null
+    ) {
+        $this->_initModule($config, $configFactory, $containerFactory, $compContainerFactory);
+        $this->_initModuleEvents($eventManager, $eventFactory);
+    }
+
+    /**
      * Initializes the module with all required information.
      *
      * @since [*next-version*]
      *
-     * @param string|Stringable         $key                  The module key.
-     * @param string[]|Stringable[]     $dependencies         The module dependencies.
-     * @param ConfigFactoryInterface    $configFactory        The config factory.
-     * @param ContainerFactoryInterface $containerFactory     The container factory.
-     * @param ContainerFactoryInterface $compContainerFactory The composite container factory.
+     * @param array|stdClass|ArrayAccess|ContainerInterface $config               The module config.
+     * @param ConfigFactoryInterface                        $configFactory        The config factory.
+     * @param ContainerFactoryInterface                     $containerFactory     The container factory.
+     * @param ContainerFactoryInterface                     $compContainerFactory The composite container factory.
      */
     protected function _initModule(
-        $key,
-        $dependencies,
+        $config,
         ConfigFactoryInterface $configFactory,
         ContainerFactoryInterface $containerFactory,
         ContainerFactoryInterface $compContainerFactory
     ) {
-        $this->_setKey($key);
-        $this->_setDependencies($dependencies);
+        $this->_setKey($this->_containerGet($config, 'key'));
+        $this->_setDependencies(
+            $this->_containerHas($config, 'dependencies')
+                ? $this->_containerGet($config, 'dependencies')
+                : []
+        );
+        $this->_setConfig($config);
         $this->_setConfigFactory($configFactory);
         $this->_setContainerFactory($containerFactory);
         $this->_setCompositeContainerFactory($compContainerFactory);
@@ -238,9 +287,13 @@ abstract class AbstractBaseModule implements
      */
     protected function _setupContainer($config, $services)
     {
+        $configData        = $this->_createCompositeContainer([$this->_getConfig(), $config]);
+        $configContainer   = $this->_createConfig($configData);
+        $servicesContainer = ($services instanceof ContainerInterface) ? $services : $this->_createContainer($services);
+
         return $this->_createCompositeContainer([
-            ($config instanceof ContainerInterface) ? $config : $this->_createConfig($config),
-            ($services instanceof ContainerInterface) ? $services : $this->_createContainer($services),
+            $configContainer,
+            $servicesContainer,
         ]);
     }
 

--- a/src/Module/AbstractBaseModule.php
+++ b/src/Module/AbstractBaseModule.php
@@ -287,7 +287,10 @@ abstract class AbstractBaseModule implements
      */
     protected function _setupContainer($config, $services)
     {
-        $configData        = $this->_createCompositeContainer([$this->_getConfig(), $config]);
+        $configData        = $this->_createCompositeContainer([
+            [$this->_getKey() => $this->_getConfig()],
+            $config,
+        ]);
         $configContainer   = $this->_createConfig($configData);
         $servicesContainer = ($services instanceof ContainerInterface) ? $services : $this->_createContainer($services);
 

--- a/test/functional/Module/AbstractBaseModuleTest.php
+++ b/test/functional/Module/AbstractBaseModuleTest.php
@@ -27,16 +27,22 @@ class AbstractBaseModuleTest extends TestCase
      *
      * @since [*next-version*]
      *
+     * @param string[] $methods The methods to mock.
+     *
      * @return TestSubject|MockObject
      */
-    public function createInstance()
+    public function createInstance(array $methods = [])
     {
         $mock = $this->getMockBuilder(static::TEST_SUBJECT_CLASSNAME)
+                     ->disableOriginalConstructor()
                      ->setMethods(
-                         [
-                             'setup',
-                             'run',
-                         ]
+                         array_merge(
+                             [
+                                 'setup',
+                                 'run',
+                             ],
+                             $methods
+                         )
                      )
                      ->getMockForAbstractClass();
 
@@ -63,6 +69,43 @@ class AbstractBaseModuleTest extends TestCase
             $subject,
             'Test subject does not implement expected interface.'
         );
+    }
+
+    /**
+     * Tests the constructor to assert whether the parameter values are correctly stored in the test subject instance.
+     *
+     * @since [*next-version*]
+     */
+    public function testConstructor()
+    {
+        $config               = [
+            'key'          => uniqid('key-'),
+            'dependencies' => [
+                uniqid('dependencies-'),
+                uniqid('dependencies-'),
+            ],
+        ];
+        $configFactory        = $this->getMockForAbstractClass('Dhii\Config\ConfigFactoryInterface');
+        $containerFactory     = $this->getMockForAbstractClass('Dhii\Data\Container\ContainerFactoryInterface');
+        $compContainerFactory = $this->getMockForAbstractClass('Dhii\Data\Container\ContainerFactoryInterface');
+
+        $builder = $this->getMockBuilder(static::TEST_SUBJECT_CLASSNAME)
+                        ->enableOriginalConstructor()
+                        ->setConstructorArgs([$config, $configFactory, $containerFactory, $compContainerFactory]);
+
+        $subject = $builder->getMockForAbstractClass();
+        $reflect = $this->reflect($subject);
+
+        $this->assertEquals($config['key'], $subject->getKey(),
+            'Module key does not match key in config.');
+        $this->assertEquals($config['dependencies'], $subject->getDependencies(),
+            'Module dependencies do not match dependencies in config.');
+        $this->assertSame($configFactory, $reflect->_getConfigFactory(),
+            'Module config factory is incorrect');
+        $this->assertSame($containerFactory, $reflect->_getContainerFactory(),
+            'Module container factory is incorrect');
+        $this->assertSame($compContainerFactory, $reflect->_getCompositeContainerFactory(),
+            'Module composite container factory is incorrect');
     }
 
     /**
@@ -134,6 +177,52 @@ class AbstractBaseModuleTest extends TestCase
         $actual = $reflect->_createContainer($definitions, $parent);
 
         $this->assertEquals($container, $actual, 'Created container is not the container created by the factory.');
+    }
+
+    /**
+     * Tests the container setup to assert whether the configs are correctly merged together and whether the merged
+     * config and the services are used to create the final container.
+     *
+     * @since [*next-version*]
+     */
+    public function testSetupContainer()
+    {
+        $subject = $this->createInstance(['_createCompositeContainer', '_createContainer', '_createConfig']);
+        $reflect = $this->reflect($subject);
+
+        $internalConfig = [];
+        $paramConfig = [];
+        $fullConfig = [];
+        $config = $this->getMockForAbstractClass('Psr\Container\ContainerInterface');
+
+        $paramServices = [];
+        $services = $this->getMockForAbstractClass('Psr\Container\ContainerInterface');
+        $container = $this->getMockForAbstractClass('Psr\Container\ContainerInterface');
+
+        $subject->expects($this->exactly(2))
+            ->method('_createCompositeContainer')
+            ->withConsecutive(
+                $this->equalTo([$internalConfig, $paramConfig]),
+                $this->equalTo([$config, $services])
+            )
+            ->willReturnOnConsecutiveCalls(
+                $fullConfig,
+                $container
+            );
+
+        $subject->expects($this->once())
+            ->method('_createConfig')
+            ->with($fullConfig)
+            ->willReturn($config);
+
+        $subject->expects($this->once())
+                ->method('_createContainer')
+                ->with($paramServices)
+                ->willReturn($services);
+
+        $actual = $reflect->_setupContainer($paramConfig, $paramServices);
+
+        $this->assertSame($container, $actual, 'Expected and returned containers do not match');
     }
 
     /**

--- a/test/unit/Config/ConfigAwareTraitTest.php
+++ b/test/unit/Config/ConfigAwareTraitTest.php
@@ -2,12 +2,12 @@
 
 namespace RebelCode\Modular\Config\FuncTest;
 
+use Exception as RootException;
 use InvalidArgumentException;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
 use RebelCode\Modular\Config\ConfigAwareTrait as TestSubject;
 use stdClass;
 use Xpmock\TestCase;
-use Exception as RootException;
-use PHPUnit_Framework_MockObject_MockObject as MockObject;
 
 /**
  * Tests {@see TestSubject}.
@@ -37,7 +37,8 @@ class ConfigAwareTraitTest extends TestCase
         $methods = $this->mergeValues(
             $methods,
             [
-                '_normalizeContainer',
+                '_createInvalidArgumentException',
+                '__',
             ]
         );
 
@@ -82,7 +83,7 @@ class ConfigAwareTraitTest extends TestCase
     public function mockClassAndInterfaces($className, $interfaceNames = [])
     {
         $paddingClassName = uniqid($className);
-        $definition = vsprintf(
+        $definition       = vsprintf(
             'abstract class %1$s extends %2$s implements %3$s {}',
             [
                 $paddingClassName,
@@ -139,17 +140,11 @@ class ConfigAwareTraitTest extends TestCase
         $subject = $this->createInstance();
         $reflect = $this->reflect($subject);
 
-        $config = new stdClass();
-        $nConfig = new stdClass();
-
-        $subject->expects($this->once())
-                ->method('_normalizeContainer')
-                ->with($config)
-                ->willReturn($nConfig);
+        $config = $this->getMockForAbstractClass('Dhii\Config\ConfigInterface');
 
         $reflect->_setConfig($config);
 
-        $this->assertSame($nConfig, $reflect->_getConfig(), 'Set and retrieved configs are not the same.');
+        $this->assertSame($config, $reflect->_getConfig(), 'Set and retrieved configs are not the same.');
     }
 
     /**
@@ -165,9 +160,8 @@ class ConfigAwareTraitTest extends TestCase
         $config = new stdClass();
 
         $subject->expects($this->once())
-                ->method('_normalizeContainer')
-                ->with($config)
-                ->willThrowException(new InvalidArgumentException());
+                ->method('_createInvalidArgumentException')
+                ->willReturn(new InvalidArgumentException());
 
         $this->setExpectedException('InvalidArgumentException');
 


### PR DESCRIPTION
Modules are now aware of a config map. The config map is used to configure the module with the correct `key` and `dependencies`, and can have any other configuration in it, as long as the config values are not services.

Thus, modules should now be injected with the config map separate from the the required services (namely the config, container and composite container factories). This config map is also merged into the final `setup()` container.

Additional tests have also been added.